### PR TITLE
Feature/open api controller

### DIFF
--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -2,21 +2,25 @@ package com.dcm.spring.druginfo.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 public class DrugOpenApiController {
     private final static String BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
     private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
 
-    @GetMapping(value = "/publicData", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<String> getDrugInfo() {
+    @GetMapping(value = "/PublicData/{itemName}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<String> getDrugInfo(@PathVariable String itemName) {
         DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
-
+        String encodedItemName = URLEncoder.encode(itemName, StandardCharsets.UTF_8);
         WebClient webClient = WebClient.builder()
                 .uriBuilderFactory(factory)
                 .baseUrl(BASE_URL)
@@ -28,7 +32,7 @@ public class DrugOpenApiController {
                         .queryParam("pageNo", "1")
                         .queryParam("numOfRows", "1")
                         .queryParam("entpName", "")
-                        .queryParam("itemName", "")
+                        .queryParam("itemName", encodedItemName)
                         .queryParam("itemSeq", "")
                         .queryParam("efcyQesitm", "")
                         .queryParam("useMethodQesitm", "")

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -1,0 +1,49 @@
+package com.dcm.spring.druginfo.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class DrugOpenApiController {
+    private final static String BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
+    private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
+
+    @GetMapping(value = "/publicData", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<String> getDrugInfo() {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+
+        WebClient webClient = WebClient.builder()
+                .uriBuilderFactory(factory)
+                .baseUrl(BASE_URL)
+                .build();
+
+        Mono<String> response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", API_KEY)
+                        .queryParam("pageNo", "1")
+                        .queryParam("numOfRows", "1")
+                        .queryParam("entpName", "")
+                        .queryParam("itemName", "")
+                        .queryParam("itemSeq", "")
+                        .queryParam("efcyQesitm", "")
+                        .queryParam("useMethodQesitm", "")
+                        .queryParam("atpnWarnQesitm", "")
+                        .queryParam("atpnQesitm", "")
+                        .queryParam("intrcQesitm", "")
+                        .queryParam("seQesitm", "")
+                        .queryParam("depositMethodQesitm", "")
+                        .queryParam("openDe", "")
+                        .queryParam("updateDe", "")
+                        .queryParam("type", "json")
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class);
+
+        return response;
+    }
+}

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/model/DrugResponseDto.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/model/DrugResponseDto.java
@@ -1,0 +1,43 @@
+package com.dcm.spring.druginfo.model;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class DrugResponseDto {
+    private Header header;
+    private Body body;
+
+    @Data
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Data
+    public static class Body {
+        private int pageNo;
+        private int totalCount;
+        private int numOfRows;
+        private List<Item> items;
+    }
+
+    @Data
+    public static class Item {
+        private String entpName;
+        private String itemName;
+        private String itemSeq;
+        private String efcyQesitm;
+        private String useMethodQesitm;
+        private String atpnWarnQesitm;
+        private String atpnQesitm;
+        private String intrcQesitm;
+        private String seQesitm;
+        private String depositMethodQesitm;
+        private String openDe;
+        private String updateDe;
+        private String itemImage;
+        private String bizrno;
+    }
+}
+


### PR DESCRIPTION
## 개요
의약품 정보를 가져오는 컨트롤러 기능 구현

## 작업 내용
공공포털 RestAPI를 활용하여 원하는 의약품의 이름을 url 쿼리에 담아 get 요청을 보내면 
해당 의약품의 정보를 반환받고 DTO 객체를 이용해서 json 파일을 파싱하는 기능까지 구현하였음  

### 추가된 사항
controller/DrugOpenApiController (공공포털 데이터를 가져와서 반환 하는 컨트롤러)
model/DrugResponseDto (의약품 정보를 파싱하는 DTO 객체)

### 변경 사항

## 이슈

## 이미지
<img width="1250" alt="image" src="https://github.com/suhanlim/DC-M-Drug-Info/assets/51906310/0575810c-ed28-41f6-98fb-aa73c54021ed">
