### PR TITLE
Feature/refactoring controller

### DIFF
--- a/druginfo/src/main/java/com/dcm/spring/druginfo/AppConfig.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/AppConfig.java
@@ -1,0 +1,16 @@
+package com.dcm.spring.druginfo;
+
+import com.dcm.spring.druginfo.service.DrugService;
+import com.dcm.spring.druginfo.service.FoodService;
+import com.dcm.spring.druginfo.service.PublicApiService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public PublicApiService publicApiService(){
+        return new DrugService();
+        // return new FoodService();
+    }
+}

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -2,6 +2,7 @@ package com.dcm.spring.druginfo.controller;
 
 import com.dcm.spring.druginfo.model.DrugResponseDto;
 import com.dcm.spring.druginfo.service.DrugService;
+import com.dcm.spring.druginfo.service.FoodService;
 import com.dcm.spring.druginfo.service.PublicApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -20,7 +21,7 @@ public class DrugOpenApiController {
     private final PublicApiService publicApiService;
 
     @Autowired
-    public DrugOpenApiController(DrugService drugService) {
+    public DrugOpenApiController(FoodService drugService) {
         this.publicApiService = drugService;
     }
 

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -2,6 +2,7 @@ package com.dcm.spring.druginfo.controller;
 
 import com.dcm.spring.druginfo.model.DrugResponseDto;
 import com.dcm.spring.druginfo.service.DrugService;
+import com.dcm.spring.druginfo.service.PublicApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,15 +17,15 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 public class DrugOpenApiController {
-    private final DrugService drugService;
+    private final PublicApiService publicApiService;
 
     @Autowired
     public DrugOpenApiController(DrugService drugService) {
-        this.drugService = drugService;
+        this.publicApiService = drugService;
     }
 
     @GetMapping(value = "/PublicData/{itemName}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<Object> getDrugInfo(@PathVariable String itemName){
-        return drugService.getInfo(itemName);
+        return publicApiService.getInfo(itemName);
     }
 }

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -1,29 +1,18 @@
 package com.dcm.spring.druginfo.controller;
 
-import com.dcm.spring.druginfo.model.DrugResponseDto;
-import com.dcm.spring.druginfo.service.DrugService;
-import com.dcm.spring.druginfo.service.FoodService;
+
 import com.dcm.spring.druginfo.service.PublicApiService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.DefaultUriBuilderFactory;
 import reactor.core.publisher.Mono;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 @RestController
+@RequiredArgsConstructor
 public class DrugOpenApiController {
     private final PublicApiService publicApiService;
-
-    @Autowired
-    public DrugOpenApiController(FoodService drugService) {
-        this.publicApiService = drugService;
-    }
 
     @GetMapping(value = "/PublicData/{itemName}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<Object> getDrugInfo(@PathVariable String itemName){

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/controller/DrugOpenApiController.java
@@ -1,6 +1,8 @@
 package com.dcm.spring.druginfo.controller;
 
 import com.dcm.spring.druginfo.model.DrugResponseDto;
+import com.dcm.spring.druginfo.service.DrugService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,44 +16,15 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 public class DrugOpenApiController {
-    private final static String BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
-    private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
+    private final DrugService drugService;
 
-    private Mono<Object> convertToMedication(DrugResponseDto drugResponseDTO) {
-        return Mono.just(drugResponseDTO.getBody().getItems().get(0));
+    @Autowired
+    public DrugOpenApiController(DrugService drugService) {
+        this.drugService = drugService;
     }
+
     @GetMapping(value = "/PublicData/{itemName}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<Object> getInfo(@PathVariable String itemName) {
-        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
-        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
-        String encodedItemName = URLEncoder.encode(itemName, StandardCharsets.UTF_8);
-        WebClient webClient = WebClient.builder()
-                .uriBuilderFactory(factory)
-                .baseUrl(BASE_URL)
-                .build();
-
-        Mono<DrugResponseDto> response = webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .queryParam("serviceKey", API_KEY)
-                        .queryParam("pageNo", "1")
-                        .queryParam("numOfRows", "1")
-                        .queryParam("entpName", "")
-                        .queryParam("itemName", encodedItemName)
-                        .queryParam("itemSeq", "")
-                        .queryParam("efcyQesitm", "")
-                        .queryParam("useMethodQesitm", "")
-                        .queryParam("atpnWarnQesitm", "")
-                        .queryParam("atpnQesitm", "")
-                        .queryParam("intrcQesitm", "")
-                        .queryParam("seQesitm", "")
-                        .queryParam("depositMethodQesitm", "")
-                        .queryParam("openDe", "")
-                        .queryParam("updateDe", "")
-                        .queryParam("type", "json")
-                        .build())
-                .retrieve()
-                .bodyToMono(DrugResponseDto.class);
-
-        return response.flatMap(this::convertToMedication);
+    public Mono<Object> getDrugInfo(@PathVariable String itemName){
+        return drugService.getInfo(itemName);
     }
 }

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/model/FoodResponseDto.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/model/FoodResponseDto.java
@@ -1,0 +1,47 @@
+package com.dcm.spring.druginfo.model;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class FoodResponseDto {
+    private Header header;
+    private Body body;
+
+    @Data
+    public static class Header {
+        private String resultCode;
+        private String resultMessage; // JSON에서는 resultMessage로 명시되어 있습니다.
+    }
+
+    @Data
+    public static class Body {
+        private List<ItemWrapper> items; // List<Object> 대신에 아래의 ItemWrapper를 사용
+        private String totalCount;
+        private String pageNo;
+        private String numOfRows;
+    }
+
+    @Data
+    public static class ItemWrapper {
+        private Item item;
+    }
+
+    @Data
+    public static class Item {
+        private String prdkindstate;
+        private String nutrient;
+        private String manufacture;
+        private String rnum;
+        private String prdkind;
+        private String rawmtrl;
+        private String prdlstNm;
+        private String imgurl2;
+        private String barcode;
+        private String imgurl1;
+        private String productGb;
+        private String prdlstReportNo;
+        private String allergy;
+    }
+}
+

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/service/DrugService.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/service/DrugService.java
@@ -11,7 +11,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 @Service
-public class DrugService {
+public class DrugService implements PublicApiService{
     private final static String BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
     private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
     public Mono<Object> getInfo(@PathVariable String itemName) {

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/service/DrugService.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/service/DrugService.java
@@ -1,0 +1,53 @@
+package com.dcm.spring.druginfo.service;
+
+import com.dcm.spring.druginfo.model.DrugResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class DrugService {
+    private final static String BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList";
+    private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
+    public Mono<Object> getInfo(@PathVariable String itemName) {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(BASE_URL);
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+        String encodedItemName = URLEncoder.encode(itemName, StandardCharsets.UTF_8);
+        WebClient webClient = WebClient.builder()
+                .uriBuilderFactory(factory)
+                .baseUrl(BASE_URL)
+                .build();
+
+        Mono<DrugResponseDto> response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", API_KEY)
+                        .queryParam("pageNo", "1")
+                        .queryParam("numOfRows", "1")
+                        .queryParam("entpName", "")
+                        .queryParam("itemName", encodedItemName)
+                        .queryParam("itemSeq", "")
+                        .queryParam("efcyQesitm", "")
+                        .queryParam("useMethodQesitm", "")
+                        .queryParam("atpnWarnQesitm", "")
+                        .queryParam("atpnQesitm", "")
+                        .queryParam("intrcQesitm", "")
+                        .queryParam("seQesitm", "")
+                        .queryParam("depositMethodQesitm", "")
+                        .queryParam("openDe", "")
+                        .queryParam("updateDe", "")
+                        .queryParam("type", "json")
+                        .build())
+                .retrieve()
+                .bodyToMono(DrugResponseDto.class);
+
+        return response.flatMap(this::convertToMedication);
+    }
+    private Mono<Object> convertToMedication(DrugResponseDto drugResponseDTO) {
+        return Mono.just(drugResponseDTO.getBody().getItems().get(0));
+    }
+}

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/service/FoodService.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/service/FoodService.java
@@ -1,0 +1,52 @@
+package com.dcm.spring.druginfo.service;
+
+import com.dcm.spring.druginfo.model.FoodResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+public class FoodService implements PublicApiService{
+    private final static String BASE_URL = "http://apis.data.go.kr/B553748/CertImgListServiceV2/getCertImgListServiceV2";
+    private final String API_KEY = "2SKRXQ8IZz8FeCOyzzs8hgyk0YWybv0fp5wAMHnsnrgPTiEqwl%2FxxQSs%2BZMHxjUSUxZWIQ37pEh9zUjkqh9zlg%3D%3D";
+    private Mono<Object> convertToMedication(FoodResponseDto foodResponseDTO) {
+        List<FoodResponseDto.ItemWrapper> items = foodResponseDTO.getBody().getItems();
+        if (items != null && !items.isEmpty()) {
+            return Mono.just(items.get(0));
+        } else {
+            return Mono.empty();  // 예시로 Mono.empty() 반환
+        }
+    }
+
+    @Override
+    public Mono<Object> getInfo(String itemName){
+        ExchangeStrategies strategies = ExchangeStrategies
+                .builder()
+                .codecs(configurer -> configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(new ObjectMapper(), MediaType.valueOf("text/json"))))
+                .build();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(BASE_URL)
+                .exchangeStrategies(strategies)
+                .build();
+
+        Mono<FoodResponseDto> response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", API_KEY)
+                        .queryParam("prdlstNm", itemName)
+                        .queryParam("returnType", "json")
+                        .queryParam("pageNo", "1")
+                        .queryParam("numOfRows", "1")
+                        .build())
+                .retrieve()
+                .bodyToMono(FoodResponseDto.class);
+
+        return response.flatMap(this::convertToMedication);
+    }
+}

--- a/druginfo/src/main/java/com/dcm/spring/druginfo/service/PublicApiService.java
+++ b/druginfo/src/main/java/com/dcm/spring/druginfo/service/PublicApiService.java
@@ -1,0 +1,7 @@
+package com.dcm.spring.druginfo.service;
+
+import reactor.core.publisher.Mono;
+
+public interface PublicApiService {
+    Mono<Object> getInfo(String query);
+}


### PR DESCRIPTION
## 개요
기존에 코드를 리팩토링 최적화 작업

## 작업 내용
컨트롤러 서비스 비즈니스 로직 분리
구현체에서 인터페이스를 의존하도록 변경
의존성 주입의 역활을 분리

### 추가된 사항
- SOLID 원칙 O 개방 패쇄의 원칙을 지키기 위해 의존성 주입을 Lombok을 이용해 간소화 하였습니다.
- Service 항목에서 식품의 이름으로 해당 식품의 정보를 받아오는 로직 구현
- SOLID 원칙의 D 의존관계 역전의 원칙에따라 구현체가 아닌 추상체와 의존 하도록 코드를 수정하였습니다.
- SOLID 원칙의 S 단일 책임의 원칙에 따라 한 개의 클래스는 단 하나의 책임만 지도록 분리하였습니다.

### 변경 사항
DrugOpenApiController -> DrugOpenApiController + DrugService

## 이슈
궁금한 사항 혹은 리뷰어들이 알아야 하는 이슈를 작성해주세요.

## 이미지
<img width="893" alt="image" src="https://github.com/suhanlim/DC-M-Drug-Info/assets/51906310/cc0c39d3-7c27-4c98-96d6-87f2452457d1">
